### PR TITLE
fixed the error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'pundit'
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass'
 gem 'simple_form'
-gem 'validates_timeliness', '~> 4.1'
 gem 'geocoder', '~> 1.6', '>= 1.6.6'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,6 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.1.0)
     tilt (2.0.10)
-    timeliness (0.4.4)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -222,8 +221,6 @@ GEM
       turbolinks-source (~> 5.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    validates_timeliness (4.1.1)
-      timeliness (>= 0.3.10, < 1)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -278,7 +275,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   turbolinks_render
   tzinfo-data
-  validates_timeliness (~> 4.1)
   web-console (>= 4.1.0)
   webdrivers
   webpacker (~> 5.0)
@@ -287,4 +283,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.14
+   2.1.4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2021_03_31_184754) do
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
#60 Had an error that broke the code.

For future reference, please keep the bundler version as 2.1.4. As previously mentioned, anything beyond 2.2.10 will break heroku.