### PR TITLE
fix end date error in display_dates file

### DIFF
--- a/app/views/trips/card/_display_dates.html.erb
+++ b/app/views/trips/card/_display_dates.html.erb
@@ -8,7 +8,7 @@
   <i class="bi bi-arrow-right mx-2"></i>
   <div class="">
     <% if trip.end_date != nil %>
-      <%= trip.start_date.strftime("%b %e, %Y,") %>
+      <%= trip.end_date.strftime("%b %e, %Y,") %>
     <% end %>
     <%= trip.expected_end_time.time.strftime("%R") %>
   </div>


### PR DESCRIPTION
We should merge this before demo. Current master shows all trips have same beginning and end date